### PR TITLE
Remove UsageString dependency

### DIFF
--- a/InflationSimulator/InflationSimulator.m
+++ b/InflationSimulator/InflationSimulator.m
@@ -12,7 +12,7 @@
 (*See on GitHub: https://github.com/maxitg/InflationSimulator.*)
 
 
-BeginPackage["InflationSimulator`", {"UsageString`"}];
+BeginPackage["InflationSimulator`"];
 
 
 InflationSimulator`Private`$PublicSymbols = Hold[{

--- a/InflationSimulator/Kernel/init.m
+++ b/InflationSimulator/Kernel/init.m
@@ -3,17 +3,4 @@
 (* Wolfram Language Init File *)
 
 
-If[PacletNewerQ[
-		"1.0", Lookup[Association[PacletInformation["UsageString"]], "Version", "-1"]],
-	With[{usageStringURL = "https://github.com/maxitg/UsageString/releases/download/" <>
-			"1.0/UsageString-1.0.paclet"},
-		If[ChoiceDialog[
-				"UsageString needs to be installed in order to use InflationSimulator." <>
-				" Install now?"],
-			PacletInstall[usageStringURL];
-		]
-	]
-]
-
-
 Get["InflationSimulator`InflationSimulator`"]


### PR DESCRIPTION
## Changes

* Remove `UsageString` dependency.

## Tests

* Check all usage strings are still displayed correctly.