### PR TITLE
Fix a bug in evolution equations

### DIFF
--- a/InflationSimulator/InflationSimulator.m
+++ b/InflationSimulator/InflationSimulator.m
@@ -100,7 +100,7 @@ $FieldSecondTimeDerivative[lagrangian_, field_, fieldDot_] :=
 	(- Sqrt[3 (-lagrangian + D[lagrangian, fieldDot] fieldDot)]
 			* D[lagrangian, fieldDot]
 		+ D[lagrangian, field]
-		- D[lagrangian, fieldDot] D[lagrangian, field, fieldDot]) /
+		- fieldDot D[lagrangian, field, fieldDot]) /
 	D[lagrangian, {fieldDot, 2}]
 
 


### PR DESCRIPTION
## Changes

* Inflation evolution equations (specifically, second field derivative) were incorrect, this is now fixed.

## Tests

* Evaluate the notebook [InflationSimulator-Bug-001.nb.zip](https://github.com/maxitg/InflationSimulator/files/2911059/InflationSimulator-Bug-001.nb.zip).
* Before, the field derivative evolved past its domain causing invalid Lagrangian values.
* Now, evaluation occurs as expected.

## Notes

* This only affects Lagrangians containing terms that both involve a field and its derivative. Thus, it affects DBI models, but not the models with a canonical kinetic term and potential.