### PR TITLE
Fix option propagation in ExperimentallyConsistentInflationQ.

### DIFF
--- a/InflationSimulator/InflationSimulator.m
+++ b/InflationSimulator/InflationSimulator.m
@@ -1479,7 +1479,7 @@ ExperimentallyConsistentInflationQ[
 			pivotEfoldings_ ? NumericQ,
 			o : OptionsPattern[]] := With[
 		{evolution = InflationEvolution[
-				lagrangian, {field, fieldInitial, fieldDerivativeInitial}, time]},
+				lagrangian, {field, fieldInitial, fieldDerivativeInitial}, time, o]},
 	InflationQ[evolution, pivotEfoldings] &&
 			ExperimentallyConsistentInflationQ @@ $InflationValue[
 					lagrangian,

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,11 +1,9 @@
 (* Paclet Info File *)
 
-(* created 2019/02/15*)
-
 Paclet[
     Name -> "InflationSimulator",
-    Version -> "0.2.1",
-    MathematicaVersion -> "11.3+",
+    Version -> "0.2.2",
+    MathematicaVersion -> "12.0+",
     Description -> "Code for simulating inflation, including Lagrangians with non-canonical kinetic energy.",
     Creator -> "Maksim Piskunov",
     Extensions -> 


### PR DESCRIPTION
## Changes

* Fix option propagation in `ExperimentallyConsistentInflationQ`. Now, `InflationEvolution` options can be used and have an effect.

## Tests

* Run `ExperimentallyConsistentInflationQ[1/2 (a'[t])^2 - (1 - Cos[a[t]/6]), {a[t], 15, 0}, t, 60, "EfoldingsDerivativeThreshold" -> 0.0625]`, which should yield `True`.
* Run `ExperimentallyConsistentInflationQ[1/2 (a'[t])^2 - (1 - Cos[a[t]/6]), {a[t], 15, 0}, t, 60, "EfoldingsDerivativeThreshold" -> 0.0625 / 10]`, which should yield `False`.
* Therefore, options now have an effect on the output of `ExperimentallyConsistentInflationQ`.