### PR TITLE
Density thresholds always on

### DIFF
--- a/InflationSimulator/InflationSimulator.m
+++ b/InflationSimulator/InflationSimulator.m
@@ -346,32 +346,28 @@ InflationEvolution[
 					Nothing]},
 				
 				(* Initialize final density thresholds *)
-				{If[endOfInflationCondition =!= Automatic,
-					WhenEvent[efoldings[time] >= initialEfoldings ||
-							scaledDensity <= initialDensityFraction,
-						{finalDensity[time], finalDensityStartTime[time]} ->
-							{scaledDensity, time},
-						"LocationMethod" -> "StepEnd"],
-					Nothing]},
+				{WhenEvent[efoldings[time] >= initialEfoldings ||
+						scaledDensity <= initialDensityFraction,
+					{finalDensity[time], finalDensityStartTime[time]} ->
+						{scaledDensity, time},
+					"LocationMethod" -> "StepEnd"]},
 				
 				(* Reached time threshold, potential end-of-inflation *)
-				{If[endOfInflationCondition =!= Automatic,
-					WhenEvent[time > finalDensityStartTime[time] /
-							(1 - finalDensityRelativeDuration),
-						If[finalDensityPrecision > 0 &&
-								finalDensity[time] - scaledDensity <=
-									finalDensityPrecision (1 - finalDensity[time]),
-							(* density is stable, check sign and stop *)
-							finalDensitySign = If[
-								scaledDensity <= zeroDensityPrecision,
-								0,
-								+1];
-							"StopIntegration",
-							(* density is still changing, set new threshold *)
-							{finalDensity[time], finalDensityStartTime[time]} ->
-								{scaledDensity, time}],
-						"LocationMethod" -> "StepEnd"],
-					Nothing]},
+				{WhenEvent[time > finalDensityStartTime[time] /
+						(1 - finalDensityRelativeDuration),
+					If[finalDensityPrecision > 0 &&
+							finalDensity[time] - scaledDensity <=
+								finalDensityPrecision (1 - finalDensity[time]),
+						(* density is stable, check sign and stop *)
+						finalDensitySign = If[
+							scaledDensity <= zeroDensityPrecision,
+							0,
+							+1];
+						"StopIntegration",
+						(* density is still changing, set new threshold *)
+						{finalDensity[time], finalDensityStartTime[time]} ->
+							{scaledDensity, time}],
+					"LocationMethod" -> "StepEnd"]},
 				 
 				(* Reached negative density, abort *)
 				{WhenEvent[scaledDensity < 0,


### PR DESCRIPTION
## Changes
* Density thresholds now always apply even if custom inflation-end condition is specified.

## Commands and tests
* Without specifying any custom conditions, integration runs for ~25 ks:
```
In[] := InflationEvolution[
 1/2 \[Phi]'[t]^2 - (1 - Cos[\[Phi][t]/10]), {{\[Phi], 30, 0}}, t]
```
![image](https://user-images.githubusercontent.com/1479325/64204360-778ad600-ce4a-11e9-8e12-e7da5644dfe8.png)

* Now, if a condition is specified, which is never triggered, the integration runs the same amount of time, due to density threshold:
```
In[] := InflationEvolution[
 1/2 \[Phi]'[t]^2 - (1 - Cos[\[Phi][t]/10]), {{\[Phi], 30, 0}}, t, 
 "EndOfInflationCondition" -> \[Phi][t] == -100]
```
![image](https://user-images.githubusercontent.com/1479325/64204434-9e490c80-ce4a-11e9-90e6-5a1bfe27e127.png)

* However, if condition is triggered, the integration stops much sooner:
```
In[] := InflationEvolution[
 1/2 \[Phi]'[t]^2 - (1 - Cos[\[Phi][t]/10]), {{\[Phi], 30, 0}}, t, 
 "EndOfInflationCondition" -> \[Phi][t] == 0]
```
![image](https://user-images.githubusercontent.com/1479325/64204480-b751bd80-ce4a-11e9-84ed-c29b3f726eb3.png)