### PR TITLE
Fix bounce counter OR to AND

### DIFF
--- a/InflationSimulator/InflationSimulator.m
+++ b/InflationSimulator/InflationSimulator.m
@@ -396,11 +396,16 @@ InflationEvolution[
 						With[{i = i},
 							WhenEvent[
 								bounces[i][time] == OptionValue["MaxBounceCount"],
-								finalDensitySign = If[
-									scaledDensity <= zeroDensityPrecision,
-									0,
-									+1];
-								"StopIntegration",
+								If[And @@ Table[
+										bounces[j][time] >=
+											OptionValue["MaxBounceCount"],
+										{j, initialConditions[[All, 1]]}],
+									finalDensitySign = If[
+										scaledDensity <= zeroDensityPrecision,
+										0,
+										+1];
+									"StopIntegration",
+								],
 								"LocationMethod" -> "StepEnd"]],
 						{i, initialConditions[[All, 1]]}]]],
 			Join[


### PR DESCRIPTION
## Changes
* The bounce counter stopped integration after the first field has reached the goal number of bounces.
* That is now fixed, the integration will be stopped after all fields reach the specified bounce count.

## Commands and tests
* Run simulation with two fields of different scales (so that they bounce at different frequencies), and a limit on bounce count:
```
In[] := evolution = 
 InflationEvolution[
  1/2 a'[t]^2 + 1/2 b'[t]^2 - a[t]^2 - 
   0.1 b[t]^2, {{a, 1, 0}, {b, 1, 0}}, t, "MaxBounceCount" -> 10, 
  "ZeroDensityRelativeThreshold" -> 1.*^-3]
```
![image](https://user-images.githubusercontent.com/1479325/64495749-fd47c080-d252-11e9-931f-b80a47ba71e5.png)
* Note integration stops when the limit for `b` is reached, even though `a` oscillates much longer than `10` bounces by then
```
In[] := Plot[{evolution[a][t], evolution[b][t]}, {t, 1, 
  evolution["IntegrationTime"]}, PlotRange -> All]
```
![image](https://user-images.githubusercontent.com/1479325/64495760-223c3380-d253-11e9-9617-16334a60d7e3.png)